### PR TITLE
Add Bird Quiz to the Apps page

### DIFF
--- a/_pages/apps.md
+++ b/_pages/apps.md
@@ -5,6 +5,8 @@ permalink: /apps/
 classes: wide
 ---
 
-Small web apps I've built, hosted on this site.
+Small web apps I've built.
 
 🚆[Elizabeth line departures](/apps/elizabeth-line/) - a live board of the next direct trains between two stations on the Elizabeth line
+
+🐦[Bird Quiz](https://birdquizapp.com/) - learn bird calls through audio quizzes: build custom quizzes from your choice of species, with recordings from Xeno-canto


### PR DESCRIPTION
## Summary

Adds 🐦 [Bird Quiz](https://birdquizapp.com/) to the `/apps/` page — an interactive web app for learning bird calls through audio quizzes, with custom quizzes built from your choice of species and recordings from Xeno-canto.

Also tweaks the page intro ("Small web apps I've built") since Bird Quiz lives on its own domain rather than on this site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QFin2ANGRiRmdvCXRvgZt

---
_Generated by [Claude Code](https://claude.ai/code/session_017QFin2ANGRiRmdvCXRvgZt)_