### PR TITLE
Fix Overhead mobile dead-scroll (use dvh for panel height)

### DIFF
--- a/_apps/overhead/OverheadTracker.jsx
+++ b/_apps/overhead/OverheadTracker.jsx
@@ -361,6 +361,8 @@ const css = `
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
+  min-height: 100dvh; /* track the visible viewport on mobile (100vh counts the
+                         area behind the browser toolbar, forcing dead scroll) */
   display: flex;
   flex-direction: column;
   max-width: 460px;

--- a/apps/overhead/app.js
+++ b/apps/overhead/app.js
@@ -18,6 +18,8 @@ Error generating stack: `+o.message+`
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
+  min-height: 100dvh; /* track the visible viewport on mobile (100vh counts the
+                         area behind the browser toolbar, forcing dead scroll) */
   display: flex;
   flex-direction: column;
   max-width: 460px;


### PR DESCRIPTION
On mobile you had to scroll down past empty space even when the content didn't reach the bottom of the screen.

## Cause
`.ovh-root` used `min-height: 100vh`. On mobile browsers, `100vh` includes the area *behind* the retractable address/toolbar, so the panel was taller than the visible viewport — producing a dead scroll region below the footer.

## Change
Add a `min-height: 100dvh` override (dynamic viewport height), which tracks the actually-visible area and shrinks/grows with the toolbar. `100vh` stays as the line above it as a fallback for browsers without `dvh` support.

`apps/overhead/app.js` rebuilt.

## Testing
Build passes. The layout change is visual and mobile-specific, so it's best confirmed on a phone after deploy; `dvh` is widely supported (iOS Safari 15.4+, Chrome 108+) and degrades to the existing `100vh` behaviour elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXr49Yjq8ao2vipgdpJG7T

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXr49Yjq8ao2vipgdpJG7T)_