### PR TITLE
Cache upstream responses in the Supabase proxy

### DIFF
--- a/_apps/overhead/DEPLOY.md
+++ b/_apps/overhead/DEPLOY.md
@@ -130,6 +130,11 @@ at that instead.
 ## Notes
 
 - **Rate limits:** airplanes.live is ~1 req/sec; the app polls once per 12s
-  per open tab, well inside that.
+  per open tab, well inside that for a single viewer. All traffic exits the one
+  proxy IP, though, so that limit is *shared* across concurrent viewers. To keep
+  load flat with audience size, the Supabase function caches upstream responses
+  in-memory (positions ~10s, static aircraft/route data ~1h), collapsing many
+  viewers polling the same URL into ~1 upstream fetch per window. The Cloudflare
+  Worker does the equivalent via Cloudflare's edge cache (`cf.cacheTtl`).
 - **Cost:** both free tiers dwarf this app's needs — Supabase allows 500K
   function invocations/month, Cloudflare 100K Worker requests/day.

--- a/_apps/overhead/supabase/functions/overhead-proxy/index.ts
+++ b/_apps/overhead/supabase/functions/overhead-proxy/index.ts
@@ -45,6 +45,24 @@ function corsHeaders(origin: string): Record<string, string> {
   };
 }
 
+// ---- Response cache ----
+// Everyone watches the same point, so without caching each viewer's poll is a
+// separate upstream request and airplanes.live's ~1 req/sec limit (shared,
+// since all traffic exits this one function) is hit at ~12 concurrent viewers.
+// A short in-memory cache (kept in the warm instance, keyed by upstream URL)
+// collapses concurrent identical requests into ~1 upstream fetch per TTL
+// window, so upstream load barely rises with audience size. CORS headers are
+// NOT cached — they're re-applied per request from the caller's origin.
+interface Cached { body: string; status: number; contentType: string; expires: number }
+const CACHE = new Map<string, Cached>();
+const CACHE_MAX = 500;
+
+// Positions change constantly; aircraft/route reference data is effectively
+// static, so it can be held much longer.
+function ttlMs(host: string): number {
+  return host === "api.airplanes.live" ? 10_000 : 3_600_000;
+}
+
 Deno.serve(async (request) => {
   const origin = request.headers.get("Origin") ?? "";
   const cors = corsHeaders(origin);
@@ -80,6 +98,17 @@ Deno.serve(async (request) => {
   }
 
   const target = new URL(`https://${host}${rest}${incoming.search}`);
+  const cacheKey = target.toString();
+  const now = Date.now();
+
+  // Serve from cache if fresh.
+  const hit = CACHE.get(cacheKey);
+  if (hit && hit.expires > now) {
+    return new Response(hit.body, {
+      status: hit.status,
+      headers: { ...cors, "Content-Type": hit.contentType, "X-Overhead-Cache": "hit" },
+    });
+  }
 
   let upstream: Response;
   try {
@@ -98,12 +127,19 @@ Deno.serve(async (request) => {
   }
 
   const body = await upstream.text();
+  const contentType = upstream.headers.get("Content-Type") ?? "application/json";
+
+  // Cache successful responses only, so errors/"unknown callsign" still retry.
+  if (upstream.status >= 200 && upstream.status < 300) {
+    if (CACHE.size >= CACHE_MAX) {
+      for (const [k, v] of CACHE) if (v.expires <= now) CACHE.delete(k);
+      if (CACHE.size >= CACHE_MAX) CACHE.delete(CACHE.keys().next().value as string);
+    }
+    CACHE.set(cacheKey, { body, status: upstream.status, contentType, expires: now + ttlMs(host) });
+  }
+
   return new Response(body, {
     status: upstream.status,
-    headers: {
-      ...cors,
-      "Content-Type":
-        upstream.headers.get("Content-Type") ?? "application/json",
-    },
+    headers: { ...cors, "Content-Type": contentType, "X-Overhead-Cache": "miss" },
   });
 });


### PR DESCRIPTION
Follow-up after #44. Prepares the app for wider sharing (e.g. a street WhatsApp group) by decoupling upstream load from viewer count.

## Why
Every viewer polls the same point through the one proxy IP, so airplanes.live's ~1 req/sec limit is *shared* across concurrent viewers — hit at ~12 simultaneous tabs.

## What
A small in-memory response cache in `supabase/functions/overhead-proxy/index.ts`, keyed by upstream URL, collapses concurrent identical requests into ~1 upstream fetch per TTL window:
- **positions (`api.airplanes.live`) ~10s** — under the 12s poll, so no perceptible staleness
- **static data (`api.adsbdb.com`) ~1h**

So upstream load stays roughly flat regardless of audience size.

Details:
- Only 2xx responses are cached, so errors / "unknown callsign" still retry.
- CORS headers are applied per-request (not cached), so the origin allow-list still gates access.
- The cache is bounded (`CACHE_MAX`): prunes expired entries, then evicts oldest.
- Responses carry an `X-Overhead-Cache: hit|miss` header for verification in the Network tab.

The Cloudflare Worker already does the equivalent via `cf.cacheTtl`; `DEPLOY.md`'s rate-limit note is updated to describe both.

## ⚠️ Requires a Supabase redeploy
This is server-side, so it only takes effect once you redeploy the `overhead-proxy` function (JWT stays off).

## Testing
Edge-function TypeScript validates via esbuild. The cache path needs upstream access to exercise, so confirm in-browser after deploy: with two tabs open, the `point/…` requests should show `X-Overhead-Cache: hit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXr49Yjq8ao2vipgdpJG7T

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXr49Yjq8ao2vipgdpJG7T)_